### PR TITLE
Change submit button name attribtue to submit-form

### DIFF
--- a/packages/custom_contact_form/blocks/custom_contact_form/view_form_fields.php
+++ b/packages/custom_contact_form/blocks/custom_contact_form/view_form_fields.php
@@ -54,4 +54,4 @@ echo $form->select('topic', $topic_options, null, array('placeholder' => 'Choose
 
 <br />
 
-<?php echo $form->submit('submit', 'Submit'); ?>
+<?php echo $form->submit('submit-form', 'Submit'); ?>


### PR DESCRIPTION
When a submit element has `name="submit"` the JavaScript form object has
its `submit` method overridden. This prevents calling `form.submit()` as
submit is now the element.
